### PR TITLE
Setup Elasticsearch use

### DIFF
--- a/accesspoc/accesspoc/settings.py
+++ b/accesspoc/accesspoc/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
+from envparse import env
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -40,7 +41,8 @@ INSTALLED_APPS = [
 
     'widget_tweaks',
 
-    'dips',
+    'dips.apps.DipsConfig',
+    'search.apps.SearchConfig',
 
     'django_cleanup'  # deletes FileFields when objects are deleted
 ]
@@ -142,3 +144,20 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 LOGOUT_REDIRECT_URL = 'home'
 LOGIN_REDIRECT_URL = 'home'
+
+# Fixtures
+
+FIXTURE_DIRS = [
+    os.path.join(BASE_DIR, 'dips', 'tests', 'fixtures'),
+]
+
+# Elasticsearch
+
+# RFC-1738 formatted URLs can be used. E.g.:'https://user:secret@host:443/'
+ES_HOSTS = env('ES_HOSTS', cast=list, subcast=str)
+ES_TIMEOUT = env.int('ES_TIMEOUT', default=10)
+ES_POOL_SIZE = env.int('ES_POOL_SIZE', default=10)
+ES_INDEXES_SETTINGS = {
+    'number_of_shards': env.int('ES_INDEXES_SHARDS', default=1),
+    'number_of_replicas': env.int('ES_INDEXES_REPLICAS', default=0),
+}

--- a/accesspoc/accesspoc/urls.py
+++ b/accesspoc/accesspoc/urls.py
@@ -1,4 +1,5 @@
-"""accesspoc URL Configuration
+"""
+accesspoc URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/1.11/topics/http/urls/

--- a/accesspoc/dips/apps.py
+++ b/accesspoc/dips/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class DipsConfig(AppConfig):
     name = 'dips'
+
+    def ready(self):
+        import dips.handlers  # noqa F401

--- a/accesspoc/dips/handlers.py
+++ b/accesspoc/dips/handlers.py
@@ -1,0 +1,22 @@
+from django.db.models.signals import post_save, pre_delete
+from django.dispatch import receiver
+
+from .models import Collection, DIP, DigitalFile
+
+
+@receiver(post_save, sender=Collection, dispatch_uid='collection_post_save')
+@receiver(post_save, sender=DIP, dispatch_uid='dip_post_save')
+@receiver(post_save, sender=DigitalFile, dispatch_uid='digital_file_post_save')
+def update_search_doc(instance, **kwargs):
+    # Disable when loading fixture data
+    if kwargs['raw']:
+        return
+    # Use refresh to reflect the changes in the index in the same request
+    instance.to_es_doc().save(refresh=True)
+
+
+@receiver(pre_delete, sender=Collection, dispatch_uid='collection_pre_delete')
+@receiver(pre_delete, sender=DIP, dispatch_uid='dip_pre_delete')
+@receiver(pre_delete, sender=DigitalFile, dispatch_uid='digital_file_pre_delete')
+def delete_search_doc(instance, **kwargs):
+    instance.delete_es_doc()

--- a/accesspoc/dips/migrations/0002_add_user_group.py
+++ b/accesspoc/dips/migrations/0002_add_user_group.py
@@ -7,12 +7,12 @@ from django.contrib.auth.management import create_permissions
 
 
 def migrate_permissions(apps, schema_editor):
-    '''
+    """
     Create permissions in migration before they are created in a
     post_migrate signal handler. They are needed to create the user
     group and the signal handler won't create duplicated permissions.
     This must be executed after the auth and dips apps are migrated.
-    '''
+    """
     for app_config in apps.get_app_configs():
         app_config.models_module = True
         create_permissions(app_config, apps=apps, verbosity=0)
@@ -20,10 +20,10 @@ def migrate_permissions(apps, schema_editor):
 
 
 def add_user_group(apps, schema_editor):
-    '''
+    """
     Create 'Edit Collections and Folders' user group with
     permissions to add and edit collections and dips.
-    '''
+    """
     Group = apps.get_model('auth', 'Group')
     Permission = apps.get_model('auth', 'Permission')
     editor_group, created = Group.objects.get_or_create(

--- a/accesspoc/dips/migrations/0003_modify_user_groups.py
+++ b/accesspoc/dips/migrations/0003_modify_user_groups.py
@@ -6,9 +6,9 @@ from django.db import migrations
 
 
 def modify_editors_user_group(apps, schema_editor):
-    '''
+    """
     Rename 'Edit Collections and Folders' user group to 'Editors'.
-    '''
+    """
     Group = apps.get_model('auth', 'Group')
     editors_group = Group.objects.get(name='Edit Collections and Folders')
     editors_group.name = 'Editors'
@@ -16,10 +16,10 @@ def modify_editors_user_group(apps, schema_editor):
 
 
 def add_managers_user_group(apps, schema_editor):
-    '''
+    """
     Create 'Managers' user group with permissions to add and edit
     collections and dips.
-    '''
+    """
     Group = apps.get_model('auth', 'Group')
     Permission = apps.get_model('auth', 'Permission')
     managers_group, created = Group.objects.get_or_create(name='Managers')

--- a/accesspoc/dips/tests/fixtures/index_data.json
+++ b/accesspoc/dips/tests/fixtures/index_data.json
@@ -1,0 +1,124 @@
+[
+{
+  "model": "dips.collection",
+  "pk": "123",
+  "fields": {}
+},
+{
+  "model": "dips.collection",
+  "pk": "456",
+  "fields": {}
+},
+{
+  "model": "dips.dip",
+  "pk": "ABC",
+  "fields": {
+    "ispartof": "123",
+    "uploaded": "2018-06-12T05:09:47.368Z"
+  }
+},
+{
+  "model": "dips.dip",
+  "pk": "DEF",
+  "fields": {
+    "ispartof": "456",
+    "uploaded": "2018-06-12T05:10:14.497Z"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "070b9cd9-a502-49c9-8b79-22abec1efd7e",
+  "fields": {
+    "size_bytes": 1361321,
+    "dip": "DEF"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "07263cdf-d11f-4d24-9e16-ef46f002d037",
+  "fields": {
+    "size_bytes": 1080282,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "35fa094d-dda9-432c-ab0c-329f798a620e",
+  "fields": {
+    "size_bytes": 1361321,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "4d6b532c-2c51-4aa3-91cd-9c4618e775a4",
+  "fields": {
+    "size_bytes": 125968,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "4fcd3a88-c994-4cc2-8f85-a28dd0b38dc6",
+  "fields": {
+    "size_bytes": 1041114,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "56864c46-fc69-4b6a-86cb-9cd78d832407",
+  "fields": {
+    "size_bytes": 4261301,
+    "dip": "DEF"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "57f074ea-e37f-4e52-afa0-6b8ca08d3137",
+  "fields": {
+    "size_bytes": 527345,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "61e8a632-2fc8-438b-8e77-e4ca2ec36fc0",
+  "fields": {
+    "size_bytes": 18324,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "92870e0b-8e38-4603-9b2c-3c93e4539ff1",
+  "fields": {
+    "size_bytes": 2050617,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "d3e6163e-4bc3-44a0-b0dd-ca43631ea71a",
+  "fields": {
+    "size_bytes": 113318,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "e019b788-267d-4c16-8254-cad01eeab3fb",
+  "fields": {
+    "size_bytes": 4261301,
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "f78f0b06-7968-4e44-afc3-0a2883375ece",
+  "fields": {
+    "size_bytes": 1437654,
+    "dip": "ABC"
+  }
+}
+]

--- a/accesspoc/dips/tests/fixtures/models_to_docs.json
+++ b/accesspoc/dips/tests/fixtures/models_to_docs.json
@@ -1,0 +1,73 @@
+[
+{
+  "model": "dips.collection",
+  "pk": "123",
+  "fields": {
+    "title": "Example collection",
+    "creator": "Example creator",
+    "subject": "Example subject",
+    "description": "Example description",
+    "publisher": "Example publisher",
+    "contributor": "Example contributor",
+    "date": "Example date",
+    "dctype": "Example type",
+    "dcformat": "Example format",
+    "source": "Example source",
+    "language": "Example language",
+    "coverage": "Example coverage",
+    "rights": "Example rights",
+    "link": "http://example.com"
+  }
+},
+{
+  "model": "dips.dip",
+  "pk": "ABC",
+  "fields": {
+    "ispartof": "123",
+    "title": "Example DIP",
+    "creator": "Example creator",
+    "subject": "Example subject",
+    "description": "Example description",
+    "publisher": "Example publisher",
+    "contributor": "Example contributor",
+    "date": "Example date",
+    "dctype": "Example type",
+    "dcformat": "Example format",
+    "source": "Example source",
+    "language": "Example language",
+    "coverage": "Example coverage",
+    "rights": "Example rights",
+    "objectszip": "example.zip",
+    "uploaded": "2018-06-12T05:09:47.368Z"
+  }
+},
+{
+  "model": "dips.digitalfile",
+  "pk": "07263cdf-d11f-4d24-9e16-ef46f002d037",
+  "fields": {
+    "filepath": "objects/example.ai",
+    "fileformat": "Adobe Illustrator",
+    "formatversion": "14.0",
+    "size_bytes": 1080282,
+    "size_human": "1 MB",
+    "datemodified": "2018-02-08T20:00:57",
+    "puid": "fmt/563",
+    "amdsec": "amdSec_3",
+    "hashtype": "sha256",
+    "hashvalue": "c0fa53ae576cc4381890099a48d5dc3f40733a3415965fb477e79503d7653b5c",
+    "dip": "ABC"
+  }
+},
+{
+  "model": "dips.premisevent",
+  "pk": "11b672df-d698-47c5-b2c6-ac85dcafcad8",
+  "fields": {
+    "eventtype": "format identification",
+    "datetime": "2018-02-08T20:15:08+00:00",
+    "detail": "program=\"Siegfried\"; version=\"1.7.6\"",
+    "outcome": "Positive",
+    "detailnote": "fmt/563",
+    "digitalfile": "07263cdf-d11f-4d24-9e16-ef46f002d037"
+  }
+}
+]

--- a/accesspoc/dips/tests/test_DIP.py
+++ b/accesspoc/dips/tests/test_DIP.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
-from django.urls import resolve
 from django.test import TestCase
+from django.urls import resolve
+from unittest.mock import patch
+
 from dips.views import dip
 from dips.models import Collection, DIP
 
@@ -10,7 +12,8 @@ import os
 
 
 class DIPTests(TestCase):
-    def setUp(self):
+    @patch('elasticsearch_dsl.DocType.save')
+    def setUp(self, patch):
         User = get_user_model()
         User.objects.create_user('temp', 'temp@example.com', 'temp')
         self.client.login(username='temp', password='temp')
@@ -27,7 +30,8 @@ class DIPTests(TestCase):
             objectszip=os.path.join(settings.MEDIA_ROOT, 'fake.zip'),
         )
 
-    def test_dip_view_success_status_code(self):
+    @patch('elasticsearch_dsl.Search.execute')
+    def test_dip_view_success_status_code(self, patch):
         url = reverse('dip', kwargs={'identifier': 'AP999.S1.001'})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/accesspoc/dips/tests/test_abstract_es_model.py
+++ b/accesspoc/dips/tests/test_abstract_es_model.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+
+from dips.models import AbstractEsModel
+
+
+class AemNoMethod(AbstractEsModel):
+    # Set to abstract to avoid 'no such table error'
+    class Meta:
+        abstract = True
+
+    es_doc = None
+
+
+class AemNoProperty(AbstractEsModel):
+    # Set to abstract to avoid 'no such table error'
+    class Meta:
+        abstract = True
+
+    def get_es_data(self):
+        return {}
+
+
+class AemOkay(AbstractEsModel):
+    # Set to abstract to avoid 'no such table error'
+    class Meta:
+        abstract = True
+
+    es_doc = None
+
+    def get_es_data(self):
+        return {}
+
+
+class AbstratEsModelTests(TestCase):
+    def test_descendants_creation(self):
+        self.assertRaises(TypeError, AemNoMethod)
+        self.assertRaises(TypeError, AemNoProperty)
+        model = AemOkay()
+        self.assertIsNone(model.es_doc)
+        self.assertEqual(model.get_es_data(), {})

--- a/accesspoc/dips/tests/test_collection.py
+++ b/accesspoc/dips/tests/test_collection.py
@@ -2,12 +2,15 @@ from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.urls import resolve
 from django.test import TestCase
+from unittest.mock import patch
+
 from dips.views import collection
 from dips.models import Collection
 
 
 class CollectionTests(TestCase):
-    def setUp(self):
+    @patch('elasticsearch_dsl.DocType.save')
+    def setUp(self, patch):
         User = get_user_model()
         User.objects.create_user('temp', 'temp@example.com', 'temp')
         self.client.login(username='temp', password='temp')
@@ -17,7 +20,8 @@ class CollectionTests(TestCase):
             link='http://fake.url',
         )
 
-    def test_collection_view_success_status_code(self):
+    @patch('elasticsearch_dsl.Search.execute')
+    def test_collection_view_success_status_code(self, patch):
         url = reverse('collection', kwargs={'identifier': 'AP999'})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/accesspoc/dips/tests/test_home.py
+++ b/accesspoc/dips/tests/test_home.py
@@ -2,6 +2,8 @@ from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.urls import resolve
 from django.test import TestCase
+from unittest.mock import patch
+
 from dips.views import home
 
 
@@ -11,7 +13,8 @@ class HomeTests(TestCase):
         User.objects.create_user('temp', 'temp@example.com', 'temp')
         self.client.login(username='temp', password='temp')
 
-    def test_home_view_status_code(self):
+    @patch('elasticsearch_dsl.Search.execute')
+    def test_home_view_status_code(self, patch):
         url = reverse('home')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/accesspoc/dips/tests/test_index_data.py
+++ b/accesspoc/dips/tests/test_index_data.py
@@ -1,0 +1,31 @@
+from django.core.management import call_command
+from django.test import TestCase
+from unittest.mock import patch
+
+from dips.models import Collection, DIP, DigitalFile
+
+
+class IndexDataTests(TestCase):
+    fixtures = ['index_data']
+
+    # Patch tqdm and print to disable output
+    @patch('search.management.commands.index_data.print')
+    @patch('search.management.commands.index_data.tqdm')
+    # Patch bulk to avoid ES requests
+    @patch('elasticsearch.Elasticsearch.bulk')
+    # Mock models get_es_data to check call_counts
+    @patch.object(Collection, 'get_es_data', return_value={})
+    @patch.object(DIP, 'get_es_data', return_value={})
+    @patch.object(DigitalFile, 'get_es_data', return_value={})
+    # Mock index create and delete to avoid ES requests and check call_counts
+    @patch('elasticsearch_dsl.Index.create')
+    @patch('elasticsearch_dsl.Index.delete')
+    def test_index_recreation(self, mock_delete, mock_create,
+                              mock_dig, mock_dip, mock_col,
+                              patch_a, patch_b, patch_c):
+        call_command('index_data')
+        self.assertEqual(mock_delete.call_count, 3)
+        self.assertEqual(mock_create.call_count, 3)
+        self.assertEqual(mock_dig.call_count, 12)
+        self.assertEqual(mock_dip.call_count, 2)
+        self.assertEqual(mock_col.call_count, 2)

--- a/accesspoc/dips/tests/test_models_to_docs.py
+++ b/accesspoc/dips/tests/test_models_to_docs.py
@@ -1,0 +1,83 @@
+from django.test import TestCase
+from unittest.mock import patch
+
+from dips.models import Collection, DIP, DigitalFile
+
+
+class ModelsToDocsTests(TestCase):
+    fixtures = ['models_to_docs']
+
+    def test_collection(self):
+        # Test data transformation
+        collection = Collection.objects.get(identifier='123')
+        doc_dict = {
+            '_id': '123',
+            'identifier': '123',
+            'title': 'Example collection',
+            'date': 'Example date',
+            'description': 'Example description',
+        }
+        self.assertEqual(doc_dict, collection.get_es_data())
+
+        # Verify DocType creation, avoid already tested transformation
+        with patch.object(Collection, 'get_es_data', return_value=doc_dict):
+            doc = collection.to_es_doc()
+            self.assertEqual(collection.identifier, doc.meta.id)
+            self.assertEqual(
+                repr(doc),
+                "CollectionDoc(index='accesspoc_collections', id='123')"
+            )
+
+    def test_dip(self):
+        # Test data transformation
+        dip = DIP.objects.get(identifier='ABC')
+        doc_dict = {
+            '_id': 'ABC',
+            'identifier': 'ABC',
+            'title': 'Example DIP',
+            'date': 'Example date',
+            'description': 'Example description',
+            'ispartof': {
+                'identifier': '123',
+                'title': 'Example collection',
+            }
+        }
+        self.assertEqual(doc_dict, dip.get_es_data())
+
+        # Verify DocType creation, avoid already tested transformation
+        with patch.object(DIP, 'get_es_data', return_value=doc_dict):
+            doc = dip.to_es_doc()
+            self.assertEqual(dip.identifier, doc.meta.id)
+            self.assertEqual(
+                repr(doc),
+                "DIPDoc(index='accesspoc_dips', id='ABC')"
+            )
+
+    def test_digital_file(self):
+        # Test data transformation
+        digital_file = DigitalFile.objects.get(
+            uuid='07263cdf-d11f-4d24-9e16-ef46f002d037'
+        )
+        doc_dict = {
+            '_id': '07263cdf-d11f-4d24-9e16-ef46f002d037',
+            'uuid': '07263cdf-d11f-4d24-9e16-ef46f002d037',
+            'filepath': 'objects/example.ai',
+            'fileformat': 'Adobe Illustrator',
+            'size_bytes': 1080282,
+            'datemodified': '2018-02-08T20:00:57',
+            'dip': {
+                'identifier': 'ABC',
+                'title': 'Example DIP',
+            }
+        }
+        self.assertEqual(doc_dict, digital_file.get_es_data())
+
+        # Verify DocType creation, avoid already tested transformation
+        with patch.object(DigitalFile, 'get_es_data', return_value=doc_dict):
+            doc = digital_file.to_es_doc()
+            self.assertEqual(digital_file.uuid, doc.meta.id)
+            self.assertEqual(
+                repr(doc),
+                "DigitalFileDoc(index='accesspoc_digital_files', "
+                "id='07263cdf-d11f-4d24-9e16-ef46f002d037')"
+            )

--- a/accesspoc/dips/tests/test_new_collection.py
+++ b/accesspoc/dips/tests/test_new_collection.py
@@ -1,8 +1,10 @@
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from dips.models import Collection
+from unittest.mock import patch
+
 from dips.forms import CollectionForm
+from dips.models import Collection
 
 
 class NewCollectionTests(TestCase):
@@ -16,7 +18,8 @@ class NewCollectionTests(TestCase):
         response = self.client.get(url)
         self.assertContains(response, 'csrfmiddlewaretoken')
 
-    def test_new_topic_valid_post_data(self):
+    @patch('elasticsearch_dsl.DocType.save')
+    def test_new_topic_valid_post_data(self, patch):
         # Make collection
         url = reverse('new_collection')
         data = {
@@ -33,20 +36,20 @@ class NewCollectionTests(TestCase):
         self.assertTrue(collection)
 
     def test_new_topic_invalid_post_data(self):
-        '''
+        """
         Invalid post data should not redirect
         The expected behavior is to show the form again with validation errors
-        '''
+        """
         url = reverse('new_collection')
         response = self.client.post(url)
         form = response.context.get('form')
         self.assertIsInstance(form, CollectionForm)
 
     def test_new_topic_invalid_post_data_empty_fields(self):
-        '''
+        """
         Invalid post data should not redirect
         The expected behavior is to show the form again with validation errors
-        '''
+        """
         url = reverse('new_collection')
         response = self.client.post(url, {})
         form = response.context.get('form')

--- a/accesspoc/dips/tests/test_signal_handlers.py
+++ b/accesspoc/dips/tests/test_signal_handlers.py
@@ -1,0 +1,75 @@
+from django.test import TestCase
+from unittest.mock import patch
+
+from dips.models import Collection, DIP, DigitalFile
+from search.documents import CollectionDoc, DIPDoc, DigitalFileDoc
+
+
+class SignalHandlerTests(TestCase):
+    @patch('elasticsearch_dsl.DocType.save')
+    def setUp(self, patch):
+        # Create resources
+        self.collection = Collection.objects.create(identifier='1')
+        self.dip = DIP.objects.create(
+            identifier='A',
+            ispartof=self.collection,
+            objectszip='/path/to/fake.zip',
+        )
+        self.digital_file = DigitalFile.objects.create(
+            uuid='fake-uuid',
+            dip=self.dip,
+            size_bytes=1
+        )
+
+    @patch.object(CollectionDoc, 'save')
+    def test_collection_post_save(self, mock):
+        Collection.objects.create(identifier='2')
+        mock.assert_called()
+
+    @patch.object(DIPDoc, 'save')
+    def test_dip_post_save(self, mock):
+        DIP.objects.create(
+            identifier='B',
+            ispartof=self.collection,
+            objectszip='/path/to/fake.zip',
+        )
+        mock.assert_called()
+
+    @patch.object(DigitalFileDoc, 'save')
+    def test_digital_file_post_save(self, mock):
+        DigitalFile.objects.create(
+            uuid='fake-uuid-2',
+            dip=self.dip,
+            size_bytes=1
+        )
+        mock.assert_called()
+
+    @patch('dips.models.delete_document')
+    def test_digital_file_pre_delete(self, mock):
+        uuid = self.digital_file.uuid
+        self.digital_file.delete()
+        mock.assert_called_with(
+            index=DigitalFile.es_doc._doc_type.index,
+            doc_type=DigitalFile.es_doc._doc_type.name,
+            id=uuid,
+        )
+
+    @patch('dips.models.delete_document')
+    def test_dip_pre_delete(self, mock):
+        identifier = self.dip.identifier
+        self.dip.delete()
+        mock.assert_called_with(
+            index=DIP.es_doc._doc_type.index,
+            doc_type=DIP.es_doc._doc_type.name,
+            id=identifier,
+        )
+
+    @patch('dips.models.delete_document')
+    def test_collection_pre_delete(self, mock):
+        identifier = self.collection.identifier
+        self.collection.delete()
+        mock.assert_called_with(
+            index=Collection.es_doc._doc_type.index,
+            doc_type=Collection.es_doc._doc_type.name,
+            id=identifier,
+        )

--- a/accesspoc/dips/tests/test_user_access.py
+++ b/accesspoc/dips/tests/test_user_access.py
@@ -1,7 +1,9 @@
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from django.contrib.auth.models import Group
+from unittest.mock import patch
+
 from dips.models import User, Collection, DIP, DigitalFile
 
 import os
@@ -116,7 +118,8 @@ GET_PAGES = {
 
 
 class UserAccessTests(TestCase):
-    def setUp(self):
+    @patch('elasticsearch_dsl.DocType.save')
+    def setUp(self, patch):
         # Create test users
         User.objects.create_superuser('admin', 'admin@example.com', 'admin')
         User.objects.create_user('basic', 'basic@example.com', 'basic')
@@ -141,11 +144,12 @@ class UserAccessTests(TestCase):
             size_bytes=1
         )
 
-    def test_get_pages(self):
-        '''
+    @patch('elasticsearch_dsl.Search.execute')
+    def test_get_pages(self, patch):
+        """
         Makes get requests to pages with different user types logged in
         and verifies if the user can see the page or gets redirected.
-        '''
+        """
         for page, responses in GET_PAGES.items():
             if page in ['edit_user']:
                 url = reverse(page, kwargs={'pk': self.user.pk})
@@ -166,10 +170,10 @@ class UserAccessTests(TestCase):
                 self.client.logout()
 
     def test_post_user(self):
-        '''
+        """
         Makes post requests to create and edit user pages with different
         user types logged in and verifies the results.
-        '''
+        """
         new_url = reverse('new_user')
         new_data = {
             'username': 'test2',
@@ -263,11 +267,12 @@ class UserAccessTests(TestCase):
         self.assertTrue(User.objects.filter(username='test_changed_2').exists())
         self.client.logout()
 
-    def test_post_collection(self):
-        '''
+    @patch('elasticsearch_dsl.DocType.save')
+    def test_post_collection(self, patch):
+        """
         Makes post requests to create and edit collection pages with different
         user types logged in and verifies the results.
-        '''
+        """
         new_url = reverse('new_collection')
         new_data = {
             'identifier': '2',
@@ -359,11 +364,12 @@ class UserAccessTests(TestCase):
         self.assertTrue(Collection.objects.filter(title='test_collection_3').exists())
         self.client.logout()
 
-    def test_post_dip(self):
-        '''
+    @patch('elasticsearch_dsl.DocType.save')
+    def test_post_dip(self, patch):
+        """
         Makes post requests to create and edit DIP pages with different
         user types logged in and verifies the results.
-        '''
+        """
         new_url = reverse('new_dip')
         new_data = {
             'identifier': 'B',
@@ -455,11 +461,12 @@ class UserAccessTests(TestCase):
         self.assertTrue(DIP.objects.filter(title='test_dip_3').exists())
         self.client.logout()
 
-    def test_delete_dip(self):
-        '''
+    @patch('dips.models.delete_document')
+    def test_delete_dip(self, patch):
+        """
         Makes post request to delete a DIP with different
         user types logged in and verifies the results.
-        '''
+        """
         url = reverse('delete_dip', kwargs={'identifier': self.dip.identifier})
         data = {
             'identifier': 'A',
@@ -513,11 +520,12 @@ class UserAccessTests(TestCase):
         after_count = len(DIP.objects.all())
         self.assertEqual(before_count, after_count + 1)
 
-    def test_delete_collection(self):
-        '''
+    @patch('dips.models.delete_document')
+    def test_delete_collection(self, patch):
+        """
         Makes post request to delete a collection with different
         user types logged in and verifies the results.
-        '''
+        """
         url = reverse('delete_collection', kwargs={'identifier': self.collection.identifier})
         data = {
             'identifier': '1',

--- a/accesspoc/dips/tests/test_user_groups.py
+++ b/accesspoc/dips/tests/test_user_groups.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+
 from dips.models import User
 
 

--- a/accesspoc/search/apps.py
+++ b/accesspoc/search/apps.py
@@ -1,0 +1,24 @@
+from django.apps import AppConfig
+from django.conf import settings
+
+from elasticsearch_dsl.connections import connections
+
+
+class SearchConfig(AppConfig):
+    name = 'search'
+
+    def ready(self):
+        """
+        Create Elasticsearch connection on app ready to do it only once. It will
+        create a persistent connection on the first request that will be used
+        globally. The client is thread safe and can be used in a multi threaded
+        environment allowing by default to open up to 10 connections per node
+        with a 10 seconds timeout. To configure the client to use SSL or HTTP
+        auth, RFC-1738 formatted URLs can be defined the hosts.
+        E.g.:'https://user:secret@host:443/'.
+        """
+        connections.create_connection(
+            hosts=settings.ES_HOSTS,
+            timeout=settings.ES_TIMEOUT,
+            maxsize=settings.ES_POOL_SIZE,
+        )

--- a/accesspoc/search/documents.py
+++ b/accesspoc/search/documents.py
@@ -1,0 +1,43 @@
+from elasticsearch_dsl import DocType, Keyword, Long, MetaField, Object, Text
+
+
+class CollectionDoc(DocType):
+    identifier = Text(fields={'raw': Keyword()})
+    title = Text()
+    date = Text()
+    description = Text()
+
+    class Meta:
+        index = 'accesspoc_collections'
+        dynamic = MetaField('strict')
+
+
+class DIPDoc(DocType):
+    identifier = Text(fields={'raw': Keyword()})
+    title = Text()
+    date = Text()
+    description = Text()
+    ispartof = Object(properties={
+        'identifier': Text(),
+        'title': Text(),
+    })
+
+    class Meta:
+        index = 'accesspoc_dips'
+        dynamic = MetaField('strict')
+
+
+class DigitalFileDoc(DocType):
+    uuid = Text()
+    filepath = Text(fields={'raw': Keyword()})
+    fileformat = Text()
+    size_bytes = Long()
+    datemodified = Text()
+    dip = Object(properties={
+        'identifier': Text(),
+        'title': Text(),
+    })
+
+    class Meta:
+        index = 'accesspoc_digital_files'
+        dynamic = MetaField('strict')

--- a/accesspoc/search/functions.py
+++ b/accesspoc/search/functions.py
@@ -1,0 +1,10 @@
+from elasticsearch_dsl.connections import connections
+
+
+def delete_document(index, doc_type, id):
+    """
+    Delete ES documents directly with the low level client to avoid building
+    the documents. Use refresh to reflect the changes in the same request.
+    """
+    es = connections.get_connection()
+    es.delete(index=index, doc_type=doc_type, id=id, refresh=True)

--- a/accesspoc/search/management/commands/index_data.py
+++ b/accesspoc/search/management/commands/index_data.py
@@ -1,0 +1,48 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from elasticsearch.helpers import streaming_bulk
+from elasticsearch_dsl import Index
+from elasticsearch_dsl.connections import connections
+from tqdm import tqdm
+
+from dips.models import Collection, DIP, DigitalFile
+
+# Tuples with display name and models to index in ES.
+MODELS = [
+    ('collections', Collection),
+    ('folders', DIP),
+    ('digital files', DigitalFile),
+]
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        es = connections.get_connection()
+        for name, model in MODELS:
+            print('Processing %s:' % name)
+            document = model.es_doc
+            index_name = document._doc_type.index
+            index = Index(index_name)
+            index.settings(**settings.ES_INDEXES_SETTINGS)
+            index.doc_type(document)
+            print(' - Deleting index.')
+            index.delete(ignore=404)
+            print(' - Creating index.')
+            index.create()
+            total = model.objects.count()
+            if total == 0:
+                print(' - No %s to index.' % name)
+                continue
+            progress_bar = tqdm(
+                total=total,
+                bar_format=' - Indexing: {n_fmt}/{total_fmt} [{elapsed} < {remaining}]',
+                ncols=1,  # required to show the custom bar_format
+            )
+            for _ in streaming_bulk(
+                es,
+                (obj.get_es_data() for obj in model.objects.all().iterator()),
+                index=index_name,
+                doc_type=document._doc_type.name,
+            ):
+                progress_bar.update(1)
+            progress_bar.close()

--- a/accesspoc/templates/collection.html
+++ b/accesspoc/templates/collection.html
@@ -10,19 +10,21 @@
 {% block content %}
   <h2>Collection description</h2>
   <br>
-  <p><strong>Identifier:</strong> {{ collection.identifier }}</p>
-  <p><strong>Title:</strong> {{ collection.title }}</p>
-  <p><strong>Date:</strong> {{ collection.date }}</p>
-  <p><strong>Creator:</strong> {{ collection.creator }}</p>
-  <p><strong>Format:</strong> {{ collection.dcformat|safe }}</p>
-  <p><strong>Description:</strong> {{ collection.description }}</p>
-  <p><strong>Finding aid:</strong> <a href="{{ collection.link }}">{{ collection.link }}</a></p>
-  {% if user.is_editor %}
-    <a href="{% url 'edit_collection' collection.identifier %}"><button class="btn btn-default">Edit</button></a>
-  {% endif %}
-  {% if user.is_superuser %}
-    <a href="{% url 'delete_collection' collection.identifier %}"><button class="btn btn-danger">Delete</button></a>
-  {% endif %}
+  <div>
+    <p><strong>Identifier:</strong> {{ collection.identifier }}</p>
+    <p><strong>Title:</strong> {{ collection.title }}</p>
+    <p><strong>Date:</strong> {{ collection.date }}</p>
+    <p><strong>Creator:</strong> {{ collection.creator }}</p>
+    <p><strong>Format:</strong> {{ collection.dcformat|safe }}</p>
+    <p><strong>Description:</strong> {{ collection.description }}</p>
+    <p><strong>Finding aid:</strong> <a href="{{ collection.link }}">{{ collection.link }}</a></p>
+    {% if user.is_editor %}
+      <a href="{% url 'edit_collection' collection.identifier %}"><button class="btn btn-default">Edit</button></a>
+    {% endif %}
+    {% if user.is_superuser %}
+      <a href="{% url 'delete_collection' collection.identifier %}"><button class="btn btn-danger">Delete</button></a>
+    {% endif %}
+  </div>
   <br>
   <h2>Folders in this collection</h2>
   <br>
@@ -35,7 +37,7 @@
         <td><strong>Description</strong></td>
         <td><strong>Details</strong></td>
       </tr>
-    {% for dip in collection.dips.all %}
+    {% for dip in dips %}
       <tr>
         <td>{{ dip.identifier }}</td>
         <td>{{ dip.title }}</td>

--- a/accesspoc/templates/dip.html
+++ b/accesspoc/templates/dip.html
@@ -47,13 +47,13 @@
         <td><strong>Last modified</strong></td>
         <td><strong>Details</strong></td>
       </tr>
-    {% for digitalfile in dip.digital_files.all|sort_by:'filepath' %}
+    {% for digital_file in digital_files %}
       <tr>
-        <td>{{ digitalfile.filepath }}</td>
-        <td>{{ digitalfile.fileformat }}</td>
-        <td>{{ digitalfile.size_bytes }}</td>
-        <td>{{ digitalfile.datemodified }}</td>
-        <td><a href="{% url 'digital_file' digitalfile.uuid %}"><button class="btn btn-primary">View</button></a></td>
+        <td>{{ digital_file.filepath }}</td>
+        <td>{{ digital_file.fileformat }}</td>
+        <td>{{ digital_file.size_bytes }}</td>
+        <td>{{ digital_file.datemodified }}</td>
+        <td><a href="{% url 'digital_file' digital_file.uuid %}"><button class="btn btn-primary">View</button></a></td>
       </tr>
     {% endfor %}
     </table>

--- a/accesspoc/templates/search.html
+++ b/accesspoc/templates/search.html
@@ -20,14 +20,14 @@
         <td><strong>Folder</strong></td>
         <td><strong>Details</strong></td>
       </tr>
-    {% for digitalfile in digitalfiles %}
+    {% for digital_file in digital_files %}
       <tr>
-        <td>{{ digitalfile.filepath }}</td>
-        <td>{{ digitalfile.fileformat }}</td>
-        <td>{{ digitalfile.size_bytes }}</td>
-        <td>{{ digitalfile.datemodified }}</td>
-        <td><a href="{% url 'dip' digitalfile.dip %}">{{ digitalfile.dip }}</a></td>
-        <td><a href="{% url 'digital_file' digitalfile.uuid %}"><button class="btn btn-primary">View</button></a></td>
+        <td>{{ digital_file.filepath }}</td>
+        <td>{{ digital_file.fileformat }}</td>
+        <td>{{ digital_file.size_bytes }}</td>
+        <td>{{ digital_file.datemodified }}</td>
+        <td><a href="{% url 'dip' digital_file.dip.identifier %}">{{ digital_file.dip.identifier }}</a></td>
+        <td><a href="{% url 'digital_file' digital_file.uuid %}"><button class="btn btn-primary">View</button></a></td>
       </tr>
     {% endfor %}
     </table>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,36 @@
 ---
 version: '3'
 
+volumes:
+  es_data:
+
+networks:
+  es_net:
+
 services:
   accesspoc:
     build: .
+    environment:
+      - ES_HOSTS=elasticsearch:9200
     volumes:
       - ./accesspoc:/src
     ports:
       - '43430:8000'
+    networks:
+      - es_net
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    environment:
+      - bootstrap.memory_lock=true
+      - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    ports:
+      - '43431:9200'
+    networks:
+      - es_net

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,11 @@
 Django==1.11.13 # pyup: <2.0
 django-cleanup==1.0.1
 django-widget-tweaks==1.4.1
+elasticsearch-dsl==6.1.0 # pyup: <7.0
+envparse==0.2.0
 gevent==1.3.2
 gunicorn==19.8.1
 lxml==4.0.0
 pytz==2017.2
+tqdm==4.23.4
 whitenoise==3.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ skipsdist = True
 basepython = python3.6
 envdir = {toxworkdir}/py36
 deps = -rrequirements/test.txt
+setenv =
+    ES_HOSTS = localhost:9200
 
 [testenv:py36]
 commands = coverage run --source='accesspoc' accesspoc/manage.py test dips


### PR DESCRIPTION
To improve the search capabilities of the application, the Collection, DIP and
DigitalFile resources will be reproduced from the database in various
Elasticsearch indexes.

- Add `elasticsearch-dsl` dependency for ES 6.x.
- Add initial ES configuration to settings using env. vars.:
  - ES_HOSTS, required.
  - ES_TIMEOUT, default: 10.
  - ES_POOL_SIZE, default: 10.
  - ES_INDEXES_SHARDS, default: 1.
  - ES_INDEXES_REPLICAS, default: 0.
- Add `envparse` dependency to handle the environment variables.
- Create `search` Django app:
  - Create default ES connection in `search.apps.SearchConfig`.
  - Create initial ES index/document definitions.
  - Create `index_data` command to recreate indexes and load data.
  - Create `functions` module with `delete_document` function.
- Add `tqdm` dependency to display progress in `index_data` command.
- Init functions for ES interactions in models.
- Add signal handlers to add/update/delete ES docs (but not in tests).
- Start using ES to query and data display in tables.
- Add tests for signals, commands and document transformations.
- Create AbstractEsModel as base for models related to ES docs:
  - Use AbstractModelMeta as its metaclass, created from ABC and
    Django model metas.
  - Implement abstract property `es_doc` to hold related ES DocType in
    descendant models.
  - Implement abstract method `get_es_data` to transform model data to
    a dictionary representation of the related ES DocType.
  - Extend AbstractEsModel in Collection, DIP and DigitalFile models.
  - Mode `to_es_doc` and `delete_es_doc` to AbstractEsModel.
  - Add AbstractEsModel descendants creation test.
- Normalize docstrings and cosmetic changes.
- Update README file:
  - Add Elasticsearch installation notes.
  - Add TOC section.
  - Add Travis CI and Codecov badges.
- Add Elasticsearch service, network and volume to Docker Compose.

TODO:
- [x] Create/update/delete ES documents when the related model changes.
- [x] Add data shown in browse tables to indexes.
- [x] Change query system to use ES.
- [x] Use ES docs to display table data.
- [x] Figure out how to handle ES in tests and add some test cases.
- [x] Improve ES indexes configuration.
- [x] Create AbstractEsModel as base for models related to ES docs.
- [x] Add documentation about env. and basic ES installation.

TODO (in other issues):
- Add all required data to ES, in #6.
- Improve query system, sorting and pagination, in #10.

Connects to #18.