### PR TITLE
Improve user groups management

### DIFF
--- a/accesspoc/accesspoc/settings.py
+++ b/accesspoc/accesspoc/settings.py
@@ -86,6 +86,7 @@ WSGI_APPLICATION = 'accesspoc.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
+# Requires MySQL or SQLite, the GROUP_CONCAT() function is being used
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/accesspoc/dips/migrations/0010_add_viewers_user_group.py
+++ b/accesspoc/dips/migrations/0010_add_viewers_user_group.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def add_viewers_user_group(apps, schema_editor):
+    """
+    Create 'Viewers' user group with no special permissions,
+    only for display purposes.
+    """
+    Group = apps.get_model('auth', 'Group')
+    Group.objects.create(name='Viewers')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dips', '0009_auto_20180721_1926'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_viewers_user_group),
+    ]

--- a/accesspoc/dips/tests/test_get_users.py
+++ b/accesspoc/dips/tests/test_get_users.py
@@ -1,0 +1,90 @@
+from django.contrib.auth.models import Group
+from django.test import TestCase
+
+from dips.models import User
+
+USERS = [
+    {
+        'username': 'JohnDoe',
+        'first_name': 'John',
+        'last_name': 'Doe',
+        'email': 'john@example.com',
+        'groups': ['Viewers'],
+    },
+    {
+        'username': 'JaneDoe',
+        'first_name': 'Jane',
+        'last_name': 'Doe',
+        'email': 'jane@example.com',
+        'groups': ['Editors', 'Managers'],
+    },
+    {
+        'username': 'JuanPerez',
+        'first_name': 'Juan',
+        'last_name': 'Perez',
+        'email': 'juan@test.com',
+        'groups': ['Editors'],
+    },
+    {
+        'username': 'MariaPerez',
+        'first_name': 'Maria',
+        'last_name': 'Perez',
+        'email': 'maria@test.com',
+        'groups': ['Managers', 'Editors', 'Viewers'],
+    },
+]
+
+
+class GetUsersTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        for user in USERS:
+            groups = user.pop('groups', None)
+            user = User.objects.create(**user)
+            if groups:
+                for group_name in groups:
+                    group = Group.objects.filter(name=group_name).get()
+                    user.groups.add(group)
+
+    def test_get_users_no_params(self):
+        """
+        Get all users without filtering, sorted by default (username).
+        """
+        users = User.get_users()
+        self.assertEqual(users.count(), 4)
+        first_user = users[0]
+        last_user = users[3]
+        self.assertEqual(first_user.username, 'JaneDoe')
+        self.assertEqual(last_user.username, 'MariaPerez')
+
+    def test_get_users_sort_by_group(self):
+        """
+        Get all users, sorted by group names concatenation.
+        """
+        users = User.get_users(sort_field='group_names')
+        self.assertEqual(users.count(), 4)
+        first_user = users[0]
+        last_user = users[3]
+        self.assertEqual(first_user.username, 'JuanPerez')
+        self.assertEqual(last_user.username, 'JohnDoe')
+
+    def test_get_users_with_query(self):
+        """Filter users by query"""
+        # Filter by query
+        users = User.get_users(query='Doe')
+        self.assertEqual(users.count(), 2)
+        # Should be case insensitive
+        users = User.get_users(query='doe')
+        self.assertEqual(users.count(), 2)
+        # Should query 'first_name'
+        users = User.get_users(query='Jane')
+        self.assertEqual(users.count(), 1)
+        # Should query 'last_name'
+        users = User.get_users(query='Perez')
+        self.assertEqual(users.count(), 2)
+        # Should query 'email'
+        users = User.get_users(query='example')
+        self.assertEqual(users.count(), 2)
+        # Should query group names concatenation
+        users = User.get_users(query='editors, managers')
+        self.assertEqual(users.count(), 2)

--- a/accesspoc/dips/views.py
+++ b/accesspoc/dips/views.py
@@ -2,7 +2,6 @@ from django.contrib.auth.models import Group
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
-from django.db.models import Q
 from django.forms import modelform_factory
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import gettext as _
@@ -127,6 +126,7 @@ def users(request):
         'first_name': 'first_name',
         'last_name': 'last_name',
         'email': 'email',
+        'groups': 'group_names'
     }
     sort_option, sort_dir = get_sort_params(request, sort_options, 'username')
     sort_field = sort_options.get(sort_option)
@@ -134,17 +134,10 @@ def users(request):
         sort_field = '-%s' % sort_field
 
     # Search
+    query = None
     if 'query' in request.GET and request.GET['query']:
         query = request.GET['query']
-        users = User.objects.order_by(sort_field).filter(
-            Q(username__icontains=query) |
-            Q(first_name__icontains=query) |
-            Q(last_name__icontains=query) |
-            Q(email__icontains=query) |
-            Q(groups__name__icontains=query)
-        )
-    else:
-        users = User.objects.order_by(sort_field).all()
+    users = User.get_users(query, sort_field)
 
     # Pagination
     page = get_page_from_search(users, request)
@@ -155,7 +148,7 @@ def users(request):
         (_('First name'), 'first_name'),
         (_('Last name'), 'last_name'),
         (_('Email'), 'email'),
-        (_('Groups'), None),
+        (_('Groups'), 'groups'),
         (_('Active'), None),
         (_('Admin'), None),
         (_('Edit'), None),

--- a/accesspoc/templates/users.html
+++ b/accesspoc/templates/users.html
@@ -25,7 +25,7 @@
           <td>{{ user.first_name }}</td>
           <td>{{ user.last_name }}</td>
           <td>{{ user.email }}</td>
-          <td>{{ user.group_names }}</td>
+          <td>{{ user.group_names|default:'' }}</td>
           <td>{{ user.is_active }}</td>
           <td>{{ user.is_superuser }}</td>
           <td><a href="{% url 'edit_user' user.pk %}"><button class="btn btn-sm btn-primary">{% trans "See more" %}</button></a></td>


### PR DESCRIPTION
- Create "Viewers" group, only for display purposes.
- Allow sorting by groups in the users table:
  - Create groups concatenation sub-query to allow sorting by group.
  - Annotate query with field containing the sub-query result.
  - Use the annotated field to query, sort and display.

Connects to #11.