### PR TITLE
Improve Elasticsearch analyzers

### DIFF
--- a/accesspoc/locale/en/LC_MESSAGES/django.po
+++ b/accesspoc/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-21 12:39+0000\n"
+"POT-Creation-Date: 2018-07-24 14:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: accesspoc/settings.py:123
+#: accesspoc/settings.py:124
 msgid "English"
 msgstr ""
 
-#: accesspoc/settings.py:124
+#: accesspoc/settings.py:125
 msgid "French"
 msgstr ""
 
-#: dips/forms.py:14 dips/views.py:98 dips/views.py:323
+#: dips/forms.py:14 dips/views.py:97 dips/views.py:316
 #: templates/includes/dc.html:4
 msgid "Identifier"
 msgstr ""
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Administrator"
 msgstr ""
 
-#: dips/forms.py:31 dips/forms.py:72 dips/views.py:158
+#: dips/forms.py:31 dips/forms.py:72 dips/views.py:151
 msgid "Groups"
 msgstr ""
 
@@ -54,140 +54,140 @@ msgstr ""
 msgid "Password and password confirmation do not match"
 msgstr ""
 
-#: dips/models.py:73
+#: dips/models.py:101
 msgid "identifier"
 msgstr ""
 
-#: dips/models.py:74
+#: dips/models.py:102
 msgid "title"
 msgstr ""
 
-#: dips/models.py:75
+#: dips/models.py:103
 msgid "creator"
 msgstr ""
 
-#: dips/models.py:76
+#: dips/models.py:104
 msgid "subject"
 msgstr ""
 
-#: dips/models.py:77
+#: dips/models.py:105
 msgid "description"
 msgstr ""
 
-#: dips/models.py:78
+#: dips/models.py:106
 msgid "publisher"
 msgstr ""
 
-#: dips/models.py:79
+#: dips/models.py:107
 msgid "contributor"
 msgstr ""
 
-#: dips/models.py:80
+#: dips/models.py:108
 msgid "date"
 msgstr ""
 
-#: dips/models.py:81
+#: dips/models.py:109
 msgid "type"
 msgstr ""
 
-#: dips/models.py:82
+#: dips/models.py:110
 msgid "format"
 msgstr ""
 
-#: dips/models.py:83
+#: dips/models.py:111
 msgid "source"
 msgstr ""
 
-#: dips/models.py:84
+#: dips/models.py:112
 msgid "language"
 msgstr ""
 
-#: dips/models.py:85
+#: dips/models.py:113
 msgid "coverage"
 msgstr ""
 
-#: dips/models.py:86
+#: dips/models.py:114
 msgid "rights"
 msgstr ""
 
-#: dips/models.py:101
+#: dips/models.py:129
 msgid "finding aid"
 msgstr ""
 
-#: dips/models.py:121
+#: dips/models.py:149
 msgid "objects zip file"
 msgstr ""
 
-#: dips/models.py:126
+#: dips/models.py:154
 msgid "collection"
 msgstr ""
 
-#: dips/views.py:99 dips/views.py:324 templates/includes/dc.html:5
+#: dips/views.py:98 dips/views.py:317 templates/includes/dc.html:5
 msgid "Title"
 msgstr ""
 
-#: dips/views.py:100 dips/views.py:325 templates/includes/dc.html:6
+#: dips/views.py:99 dips/views.py:318 templates/includes/dc.html:6
 msgid "Date"
 msgstr ""
 
-#: dips/views.py:101 dips/views.py:326 templates/includes/dc.html:9
+#: dips/views.py:100 dips/views.py:319 templates/includes/dc.html:9
 msgid "Description"
 msgstr ""
 
-#: dips/views.py:102 dips/views.py:327 dips/views.py:372
+#: dips/views.py:101 dips/views.py:320 dips/views.py:365
 msgid "Details"
 msgstr ""
 
-#: dips/views.py:154
+#: dips/views.py:147
 msgid "Username"
 msgstr ""
 
-#: dips/views.py:155
+#: dips/views.py:148
 msgid "First name"
 msgstr ""
 
-#: dips/views.py:156
+#: dips/views.py:149
 msgid "Last name"
 msgstr ""
 
-#: dips/views.py:157
+#: dips/views.py:150
 msgid "Email"
 msgstr ""
 
-#: dips/views.py:159
+#: dips/views.py:152
 msgid "Active"
 msgstr ""
 
-#: dips/views.py:160
+#: dips/views.py:153
 msgid "Admin"
 msgstr ""
 
-#: dips/views.py:161 templates/collection.html:21 templates/dip.html:23
+#: dips/views.py:154 templates/collection.html:21 templates/dip.html:23
 #: templates/edit_collection.html:12 templates/edit_dip.html:14
 msgid "Edit"
 msgstr ""
 
-#: dips/views.py:281 dips/views.py:368 templates/digitalfile.html:22
+#: dips/views.py:274 dips/views.py:361 templates/digitalfile.html:22
 msgid "Filepath"
 msgstr ""
 
-#: dips/views.py:282 dips/views.py:369 templates/includes/dc.html:8
+#: dips/views.py:275 dips/views.py:362 templates/includes/dc.html:8
 msgid "Format"
 msgstr ""
 
-#: dips/views.py:283 dips/views.py:370 templates/digitalfile.html:25
+#: dips/views.py:276 dips/views.py:363 templates/digitalfile.html:25
 msgid "Size (bytes)"
 msgstr ""
 
-#: dips/views.py:284 dips/views.py:371
+#: dips/views.py:277 dips/views.py:364
 msgid "Last modified"
 msgstr ""
 
-#: dips/views.py:285
+#: dips/views.py:278
 msgid "View parent folder"
 msgstr ""
 
-#: dips/views.py:286
+#: dips/views.py:279
 msgid "File details"
 msgstr ""
 

--- a/accesspoc/locale/fr/LC_MESSAGES/django.po
+++ b/accesspoc/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-21 12:39+0000\n"
+"POT-Creation-Date: 2018-07-24 14:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: accesspoc/settings.py:123
+#: accesspoc/settings.py:124
 msgid "English"
 msgstr ""
 
-#: accesspoc/settings.py:124
+#: accesspoc/settings.py:125
 msgid "French"
 msgstr ""
 
-#: dips/forms.py:14 dips/views.py:98 dips/views.py:323
+#: dips/forms.py:14 dips/views.py:97 dips/views.py:316
 #: templates/includes/dc.html:4
 msgid "Identifier"
 msgstr ""
@@ -39,7 +39,7 @@ msgstr ""
 msgid "Administrator"
 msgstr ""
 
-#: dips/forms.py:31 dips/forms.py:72 dips/views.py:158
+#: dips/forms.py:31 dips/forms.py:72 dips/views.py:151
 msgid "Groups"
 msgstr ""
 
@@ -55,140 +55,140 @@ msgstr ""
 msgid "Password and password confirmation do not match"
 msgstr ""
 
-#: dips/models.py:73
+#: dips/models.py:101
 msgid "identifier"
 msgstr ""
 
-#: dips/models.py:74
+#: dips/models.py:102
 msgid "title"
 msgstr ""
 
-#: dips/models.py:75
+#: dips/models.py:103
 msgid "creator"
 msgstr ""
 
-#: dips/models.py:76
+#: dips/models.py:104
 msgid "subject"
 msgstr ""
 
-#: dips/models.py:77
+#: dips/models.py:105
 msgid "description"
 msgstr ""
 
-#: dips/models.py:78
+#: dips/models.py:106
 msgid "publisher"
 msgstr ""
 
-#: dips/models.py:79
+#: dips/models.py:107
 msgid "contributor"
 msgstr ""
 
-#: dips/models.py:80
+#: dips/models.py:108
 msgid "date"
 msgstr ""
 
-#: dips/models.py:81
+#: dips/models.py:109
 msgid "type"
 msgstr ""
 
-#: dips/models.py:82
+#: dips/models.py:110
 msgid "format"
 msgstr ""
 
-#: dips/models.py:83
+#: dips/models.py:111
 msgid "source"
 msgstr ""
 
-#: dips/models.py:84
+#: dips/models.py:112
 msgid "language"
 msgstr ""
 
-#: dips/models.py:85
+#: dips/models.py:113
 msgid "coverage"
 msgstr ""
 
-#: dips/models.py:86
+#: dips/models.py:114
 msgid "rights"
 msgstr ""
 
-#: dips/models.py:101
+#: dips/models.py:129
 msgid "finding aid"
 msgstr ""
 
-#: dips/models.py:121
+#: dips/models.py:149
 msgid "objects zip file"
 msgstr ""
 
-#: dips/models.py:126
+#: dips/models.py:154
 msgid "collection"
 msgstr ""
 
-#: dips/views.py:99 dips/views.py:324 templates/includes/dc.html:5
+#: dips/views.py:98 dips/views.py:317 templates/includes/dc.html:5
 msgid "Title"
 msgstr ""
 
-#: dips/views.py:100 dips/views.py:325 templates/includes/dc.html:6
+#: dips/views.py:99 dips/views.py:318 templates/includes/dc.html:6
 msgid "Date"
 msgstr ""
 
-#: dips/views.py:101 dips/views.py:326 templates/includes/dc.html:9
+#: dips/views.py:100 dips/views.py:319 templates/includes/dc.html:9
 msgid "Description"
 msgstr ""
 
-#: dips/views.py:102 dips/views.py:327 dips/views.py:372
+#: dips/views.py:101 dips/views.py:320 dips/views.py:365
 msgid "Details"
 msgstr ""
 
-#: dips/views.py:154
+#: dips/views.py:147
 msgid "Username"
 msgstr ""
 
-#: dips/views.py:155
+#: dips/views.py:148
 msgid "First name"
 msgstr ""
 
-#: dips/views.py:156
+#: dips/views.py:149
 msgid "Last name"
 msgstr ""
 
-#: dips/views.py:157
+#: dips/views.py:150
 msgid "Email"
 msgstr ""
 
-#: dips/views.py:159
+#: dips/views.py:152
 msgid "Active"
 msgstr ""
 
-#: dips/views.py:160
+#: dips/views.py:153
 msgid "Admin"
 msgstr ""
 
-#: dips/views.py:161 templates/collection.html:21 templates/dip.html:23
+#: dips/views.py:154 templates/collection.html:21 templates/dip.html:23
 #: templates/edit_collection.html:12 templates/edit_dip.html:14
 msgid "Edit"
 msgstr ""
 
-#: dips/views.py:281 dips/views.py:368 templates/digitalfile.html:22
+#: dips/views.py:274 dips/views.py:361 templates/digitalfile.html:22
 msgid "Filepath"
 msgstr ""
 
-#: dips/views.py:282 dips/views.py:369 templates/includes/dc.html:8
+#: dips/views.py:275 dips/views.py:362 templates/includes/dc.html:8
 msgid "Format"
 msgstr ""
 
-#: dips/views.py:283 dips/views.py:370 templates/digitalfile.html:25
+#: dips/views.py:276 dips/views.py:363 templates/digitalfile.html:25
 msgid "Size (bytes)"
 msgstr ""
 
-#: dips/views.py:284 dips/views.py:371
+#: dips/views.py:277 dips/views.py:364
 msgid "Last modified"
 msgstr ""
 
-#: dips/views.py:285
+#: dips/views.py:278
 msgid "View parent folder"
 msgstr ""
 
-#: dips/views.py:286
+#: dips/views.py:279
 msgid "File details"
 msgstr ""
 

--- a/accesspoc/search/documents.py
+++ b/accesspoc/search/documents.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import DocType, InnerDoc, Keyword, Long, \
+from elasticsearch_dsl import analyzer, DocType, InnerDoc, Keyword, Long, \
     MetaField, Object, Text, Integer
 
 
@@ -31,7 +31,16 @@ class DIPDoc(DocType):
 
 class DigitalFileDoc(DocType):
     uuid = Text()
-    filepath = Text(fields={'raw': Keyword()})
+    # To split file extensions, the pattern tokenizer is used,
+    # which defaults to the "\W+" pattern.
+    filepath = Text(
+        fields={'raw': Keyword()},
+        analyzer=analyzer(
+            'filepath',
+            tokenizer='pattern',
+            filter=['lowercase'],
+        ),
+    )
     fileformat = Text(fields={'raw': Keyword()})
     size_bytes = Long()
     # TODO: Use date time field for datemodified, see #54

--- a/accesspoc/search/management/commands/index_data.py
+++ b/accesspoc/search/management/commands/index_data.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from elasticsearch.helpers import streaming_bulk
-from elasticsearch_dsl import Index
+from elasticsearch_dsl import analyzer, Index
 from elasticsearch_dsl.connections import connections
 from tqdm import tqdm
 
@@ -24,6 +24,9 @@ class Command(BaseCommand):
             index_name = document._doc_type.index
             index = Index(index_name)
             index.settings(**settings.ES_INDEXES_SETTINGS)
+            # Use English analizer by default, other analyzers may be
+            # defined in the documents declaration for specific fields.
+            index.analyzer(analyzer('default', 'english'))
             index.doc_type(document)
             print(' - Deleting index.')
             index.delete(ignore=404)


### PR DESCRIPTION
- Use 'english' analyzer by default.
- Add custom analyzer for Digital Files 'filepath' to split file 
extensions.
- Update messages files.

Connects to #18.