### PR TITLE
Submit language form on language link click

### DIFF
--- a/accesspoc/static/js/custom.js
+++ b/accesspoc/static/js/custom.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+  /*
+  Language link click listener:
+  Changes the language hidden input value on the sibling language
+  form with the language clode included in the 'data-language'
+  attribute from the link and submits the form.
+  */
+  $('body').on('click', 'a.change-language', function(event) {
+    event.preventDefault();
+    var $this = $(this);
+    var $form = $($this.siblings('#language-form')[0]);
+    $form.find('input[name="language"]').val($this.data('language'));
+    $form.submit();
+  });
+});

--- a/accesspoc/templates/base.html
+++ b/accesspoc/templates/base.html
@@ -6,9 +6,10 @@
   <head>
     <meta charset="utf-8">
     <title>{% block title %}{% endblock %}</title>
-    <script src="{% static 'js/jquery-3.2.1.min.js' %}"></script>
-    <script src="{% static 'js/popper.min.js' %}"></script>
-    <script src="{% static 'js/bootstrap.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/jquery-3.2.1.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/popper.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/bootstrap.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/custom.js' %}"></script>
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'fontawesome/css/fontawesome.css' %}">
     <link rel="stylesheet" href="{% static 'fontawesome/css/solid.css' %}">
@@ -35,24 +36,16 @@
               <span class="sr-only">{% trans "Select language" %}</span>
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="langMenu">
-              {% get_current_language as LANGUAGE_CODE %}
-              {% get_available_languages as LANGUAGES %}
-              {% get_language_info_list for LANGUAGES as languages %}
-              <form action="{% url 'set_language' %}" method="post" class="px-3 py-2">
+              <form id="language-form" action="{% url 'set_language' %}" method="post">
                 {% csrf_token %}
                 <input name="next" type="hidden" value="{{ redirect_to }}" />
-                {% for language in languages %}
-                  <div class="form-group form-check">
-                    <input class="form-check-input" type="radio" name="language" id="lang_{{ language.code }}" value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} checked="checked"{% endif %}>
-                    <label class="form-check-label" for="lang_{{ language.code }}">
-                      {{ language.name_local|capfirst }} ({{ language.code }})
-                    </label>
-                  </div>
-                {% endfor %}
-                <div class="text-right">
-                  <button type="submit" class="btn btn-sm btn-primary">{% trans "Submit" %}</button>
-                </div>
+                <input name="language" type="hidden" />
               </form>
+              {% get_available_languages as LANGUAGES %}
+              {% get_language_info_list for LANGUAGES as languages %}
+              {% for language in languages %}
+                <a class="dropdown-item change-language" href="#" data-language="{{ language.code }}">{{ language.name_local|capfirst }} ({{ language.code }})</a>
+              {% endfor %}
             </div>
           </li>
           {% if user.is_authenticated %}


### PR DESCRIPTION
To avoid having a submit button inside the language drop-down to send
the language change request, create a hidden field inside the form for
the language and remove the current check-boxes. Add drop-down links
outside the form and change the language input value on link click and
submit the form.

Connects to #16.