### PR TITLE
Fix deletion of Collections and DIPs

### DIFF
--- a/dips/apps.py
+++ b/dips/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class DipsConfig(AppConfig):
+    name = 'dips'
+
+    def ready(self):
+        import dips.handlers  # noqa F401

--- a/dips/handlers.py
+++ b/dips/handlers.py
@@ -1,0 +1,17 @@
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+
+from .models import Collection, DIP
+
+
+@receiver(pre_delete, sender=Collection, dispatch_uid='collection_pre_delete')
+@receiver(pre_delete, sender=DIP, dispatch_uid='dip_pre_delete')
+def delete_related_dc(instance, **kwargs):
+    # When cascade deleting related models the custom delete method from
+    # the model classes is not called. The DublinCore models are not deleted
+    # in the cascade process because they're related to both Collection and DIP
+    # models from their respective tables due to the lack of a base model,
+    # where the relation could be made from the DublinCore model to the base
+    # model and use on delete cascade for that one to one relation.
+    if instance.dc:
+        instance.dc.delete()

--- a/dips/models.py
+++ b/dips/models.py
@@ -107,8 +107,6 @@ class AbstractEsModel(models.Model, metaclass=AbstractModelMeta):
         Extended delete to update related documents in ES and remove related
         DublinCore in Collections and DIPs.
         """
-        if type(self) in [Collection, DIP] and self.dc:
-            self.dc.delete()
         self.delete_es_doc()
         super(AbstractEsModel, self).delete(*args, **kwargs)
 

--- a/dips/tasks.py
+++ b/dips/tasks.py
@@ -71,7 +71,7 @@ def extract_and_parse_mets(dip_id, zip_path):
 
 @shared_task(
     autoretry_for=(TransportError, DatabaseError,),
-    max_retries=10, default_retry_delay=30,
+    max_retries=10, default_retry_delay=30, ignore_result=True
 )
 def update_es_descendants(class_name, pk):
     """
@@ -147,7 +147,7 @@ def update_es_descendants(class_name, pk):
 
 @shared_task(
     autoretry_for=(TransportError,),
-    max_retries=10, default_retry_delay=30,
+    max_retries=10, default_retry_delay=30, ignore_result=True
 )
 def delete_es_descendants(class_name, pk):
     """Deletes the related documents in ES based on the ancestor id."""

--- a/dips/tests/test_abstract_es_model.py
+++ b/dips/tests/test_abstract_es_model.py
@@ -4,6 +4,7 @@ from dips.models import AbstractEsModel
 
 
 class AemNoMethod(AbstractEsModel):
+    """Model missing one or more abstract methods."""
     # Set to abstract to avoid 'no such table error'
     class Meta:
         abstract = True
@@ -15,6 +16,7 @@ class AemNoMethod(AbstractEsModel):
 
 
 class AemNoProperty(AbstractEsModel):
+    """Model missing one or more abstract properties."""
     # Set to abstract to avoid 'no such table error'
     class Meta:
         abstract = True
@@ -25,8 +27,12 @@ class AemNoProperty(AbstractEsModel):
     def requires_es_descendants_update(self):
         pass
 
+    def requires_es_descendants_delete(self):
+        pass
+
 
 class AemOkay(AbstractEsModel):
+    """Model with all the abstract models and properties."""
     # Set to abstract to avoid 'no such table error'
     class Meta:
         abstract = True
@@ -37,6 +43,9 @@ class AemOkay(AbstractEsModel):
         pass
 
     def requires_es_descendants_update(self):
+        pass
+
+    def requires_es_descendants_delete(self):
         pass
 
 

--- a/dips/tests/test_dc_deletion.py
+++ b/dips/tests/test_dc_deletion.py
@@ -17,7 +17,8 @@ class DcDeletionTests(TestCase):
         )
 
     @patch('elasticsearch.client.Elasticsearch.delete')
-    def test_dip_deletion(self, patch):
+    @patch('dips.models.celery_app.send_task')
+    def test_dip_deletion(self, patch, patch_2):
         dc_count = DublinCore.objects.filter(identifier='A').count()
         self.assertEqual(dc_count, 1)
         self.dip.delete()
@@ -25,7 +26,8 @@ class DcDeletionTests(TestCase):
         self.assertEqual(dc_count, 0)
 
     @patch('elasticsearch.client.Elasticsearch.delete')
-    def test_collection_deletion(self, patch):
+    @patch('dips.models.celery_app.send_task')
+    def test_collection_deletion(self, patch, patch_2):
         dc_count = DublinCore.objects.all().count()
         self.assertEqual(dc_count, 2)
         self.collection.delete()

--- a/dips/tests/test_dc_deletion.py
+++ b/dips/tests/test_dc_deletion.py
@@ -26,8 +26,9 @@ class DcDeletionTests(TestCase):
 
     @patch('elasticsearch.client.Elasticsearch.delete')
     def test_collection_deletion(self, patch):
-        dc_count = DublinCore.objects.filter(identifier='1').count()
-        self.assertEqual(dc_count, 1)
+        dc_count = DublinCore.objects.all().count()
+        self.assertEqual(dc_count, 2)
         self.collection.delete()
-        dc_count = DublinCore.objects.filter(identifier='1').count()
+        # It should also delete the DIP DublinCore
+        dc_count = DublinCore.objects.all().count()
         self.assertEqual(dc_count, 0)

--- a/dips/tests/test_delete_by_dc_form.py
+++ b/dips/tests/test_delete_by_dc_form.py
@@ -31,7 +31,8 @@ class DcByDcFormTests(TestCase):
         self.assertTrue(form.fields['identifier'].error_messages)
 
     @patch('elasticsearch.client.Elasticsearch.delete')
-    def test_dip_deletion_success(self, patch):
+    @patch('dips.models.celery_app.send_task')
+    def test_dip_deletion_success(self, patch, patch_2):
         url = reverse('delete_dip', kwargs={'pk': self.dip.pk})
         self.assertTrue(DIP.objects.filter(dc__identifier='A').exists())
         self.client.post(url, {'identifier': 'A'})
@@ -47,7 +48,8 @@ class DcByDcFormTests(TestCase):
         self.assertTrue(form.fields['identifier'].error_messages)
 
     @patch('elasticsearch.client.Elasticsearch.delete')
-    def test_collection_deletion_success(self, patch):
+    @patch('dips.models.celery_app.send_task')
+    def test_collection_deletion_success(self, patch, patch_2):
         url = reverse('delete_collection', kwargs={'pk': self.collection.pk})
         self.assertTrue(Collection.objects.filter(dc__identifier='1').exists())
         self.client.post(url, {'identifier': '1'})

--- a/dips/tests/test_es_models_save_delete.py
+++ b/dips/tests/test_es_models_save_delete.py
@@ -56,8 +56,9 @@ class EsModelsSaveDeleteTests(TestCase):
         mock.assert_called()
         mock_2.assert_not_called()
 
+    @patch('dips.models.celery_app.send_task')
     @patch('dips.models.delete_document')
-    def test_digital_file_delete(self, mock):
+    def test_digital_file_delete(self, mock, mock_2):
         uuid = self.digital_file.uuid
         self.digital_file.delete()
         mock.assert_called_with(
@@ -65,9 +66,11 @@ class EsModelsSaveDeleteTests(TestCase):
             doc_type=DigitalFile.es_doc._doc_type.name,
             id=uuid,
         )
+        mock_2.assert_not_called()
 
+    @patch('dips.models.celery_app.send_task')
     @patch('dips.models.delete_document')
-    def test_dip_delete(self, mock):
+    def test_dip_delete(self, mock, mock_2):
         pk = self.dip.pk
         self.dip.delete()
         mock.assert_called_with(
@@ -75,9 +78,13 @@ class EsModelsSaveDeleteTests(TestCase):
             doc_type=DIP.es_doc._doc_type.name,
             id=pk,
         )
+        mock_2.assert_called_with(
+            'dips.tasks.delete_es_descendants',
+            args=('DIP', 1))
 
+    @patch('dips.models.celery_app.send_task')
     @patch('dips.models.delete_document')
-    def test_collection_delete(self, mock):
+    def test_collection_delete(self, mock, mock_2):
         pk = self.collection.pk
         self.collection.delete()
         mock.assert_called_with(
@@ -85,3 +92,6 @@ class EsModelsSaveDeleteTests(TestCase):
             doc_type=Collection.es_doc._doc_type.name,
             id=pk,
         )
+        mock_2.assert_called_with(
+            'dips.tasks.delete_es_descendants',
+            args=('Collection', 1))

--- a/dips/tests/test_user_access.py
+++ b/dips/tests/test_user_access.py
@@ -511,7 +511,8 @@ class UserAccessTests(TestCase):
         self.client.logout()
 
     @patch('dips.models.delete_document')
-    def test_delete_dip(self, patch):
+    @patch('dips.models.celery_app.send_task')
+    def test_delete_dip(self, patch, patch_2):
         """
         Makes post request to delete a DIP with different
         user types logged in and verifies the results.
@@ -571,7 +572,8 @@ class UserAccessTests(TestCase):
         self.assertEqual(before_count, after_count + 1)
 
     @patch('dips.models.delete_document')
-    def test_delete_collection(self, patch):
+    @patch('dips.models.celery_app.send_task')
+    def test_delete_collection(self, patch, patch_2):
         """
         Makes post request to delete a collection with different
         user types logged in and verifies the results.

--- a/dips/views.py
+++ b/dips/views.py
@@ -581,6 +581,12 @@ def delete_collection(request, pk):
         initial={'identifier': ''},
     )
     if form.is_valid():
+        if collection.requires_es_descendants_delete():
+            messages.info(request, _(
+                'A background process has been launched to delete the '
+                'descendant Folders and Digital Files from the Elasticsearch '
+                'indexes.'
+            ))
         collection.delete()
         return redirect('collections')
 
@@ -606,6 +612,11 @@ def delete_dip(request, pk):
     )
     if form.is_valid():
         collection_pk = dip.collection.pk
+        if dip.requires_es_descendants_delete():
+            messages.info(request, _(
+                'A background process has been launched to delete the '
+                'descendant Digital Files from the Elasticsearch index.'
+            ))
         dip.delete()
         return redirect('collection', pk=collection_pk)
 

--- a/scope/settings.py
+++ b/scope/settings.py
@@ -36,7 +36,7 @@ INSTALLED_APPS = [
     'django_celery_results',
     'widget_tweaks',
 
-    'dips',
+    'dips.apps.DipsConfig',
     'search.apps.SearchConfig',
 
     'django_cleanup'  # deletes FileFields when objects are deleted


### PR DESCRIPTION
**Add new `pre_delete` signal handler:**

Required to delete the related DublinCore model for Collections and
DIPs as the custom `delete` method is not called on cascade deleting.

**Delete descendant DIPs and DigitalFiles from ES:**

When a Collection or DIP is deleted, check descendants existence and
delete the descendant documents in the related ES indexes from a Celery
task. Use low level client `delete_by_query` to be able to delete over
multiple indexes at the same time. For example, when a Collection is
deleted, to be able to delete the related DIPs and DigitalFiles, which
share the same field in their indexes for the Collection id.

- Add `delete_es_descendants` Celery task.
- Add abstract method to ES models to check need of descendants update.
- Call async. task when descendant update is needed.
- Show alert to user about delete in progress.
- Fix, improve and add tests.

**Ignore result in ES related tasks:**

Avoids hitting the database to add a task result that is not being
considered at this point.

Connects to #123.