### PR TITLE
Pin kombu dependency to 4.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ envparse==0.2.0
 gevent==1.3.6
 gunicorn==19.8.1
 jsonfield2==3.0.1
+kombu==4.3.0
 libsass==0.14.5
 lxml==4.2.4
 pytz==2018.5


### PR DESCRIPTION
Required by celery and recently upgraded causing some issues with redis
2.x. It will be removed or updated when celery is upgraded to >=4.3 and
redis to >=3.2.

Connects to #127.