### PR TITLE
Add UI adjustments

### DIFF
--- a/dips/templatetags/custom_tags.py
+++ b/dips/templatetags/custom_tags.py
@@ -1,5 +1,7 @@
 from django import template
 
+import os
+
 register = template.Library()
 
 
@@ -34,3 +36,9 @@ def render_label(field):
 def render_label_with_class(field, class_attr):
     """Add class attribute to field label tag and render without suffix."""
     return field.label_tag(attrs={'class': class_attr}, label_suffix='')
+
+
+@register.filter
+def basename(path):
+    """Returns the filename from a path."""
+    return os.path.basename(path)

--- a/dips/views.py
+++ b/dips/views.py
@@ -274,7 +274,7 @@ def search(request):
     table_headers = [
         {'label': _('Filepath'), 'sort_param': 'path'},
         {'label': _('Format'), 'sort_param': 'format'},
-        {'label': _('Size (bytes)'), 'sort_param': 'size'},
+        {'label': _('Size'), 'sort_param': 'size'},
         {'label': _('Last modified'), 'sort_param': 'date'},
         {'label': _('Collection name')},
         {'label': _('File details')},
@@ -386,7 +386,7 @@ def dip(request, pk):
     table_headers = [
         {'label': _('Filepath'), 'sort_param': 'path'},
         {'label': _('Format'), 'sort_param': 'format'},
-        {'label': _('Size (bytes)'), 'sort_param': 'size'},
+        {'label': _('Size'), 'sort_param': 'size'},
         {'label': _('Last modified'), 'sort_param': 'date'},
         {'label': _('File details')},
     ]

--- a/dips/views.py
+++ b/dips/views.py
@@ -258,7 +258,7 @@ def search(request):
             'terms',
             **{'dip.import_status': [DIP.IMPORT_PENDING, DIP.IMPORT_FAILURE]},
         )
-    fields = ['filepath', 'fileformat', 'dip.identifier', 'collection.title']
+    fields = ['filepath', 'fileformat', 'collection.title']
     search = add_query_to_search(search, request.GET.get('query', ''), fields)
     search = search.sort({sort_field: {'order': sort_dir}})
 
@@ -277,7 +277,6 @@ def search(request):
         {'label': _('Size (bytes)'), 'sort_param': 'size'},
         {'label': _('Last modified'), 'sort_param': 'date'},
         {'label': _('Collection name')},
-        {'label': _('View parent folder')},
         {'label': _('File details')},
     ]
 

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -9,8 +9,9 @@
 
 {% block content %}
   <ol class="breadcrumb">
+    {% trans "Untitled" as untitled %}
     <li class="breadcrumb-item"><a href="{% url 'collections' %}">{% trans "Collections" %}</a></li>
-    <li class="breadcrumb-item active">{{ collection }}</li>
+    <li class="breadcrumb-item active">{{ collection.dc.title|default:untitled }}</li>
   </ol>
   <div class="row">
     <div class="col">

--- a/templates/delete_collection.html
+++ b/templates/delete_collection.html
@@ -7,8 +7,9 @@
 
 {% block content %}
   <ol class="breadcrumb">
+    {% trans "Untitled" as untitled %}
     <li class="breadcrumb-item"><a href="{% url 'collections' %}">{% trans "Collections" %}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'collection' collection.pk %}">{{ collection }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'collection' collection.pk %}">{{ collection.dc.title|default:untitled }}</a></li>
     <li class="breadcrumb-item active">{% trans "Delete" %}</li>
   </ol>
   <h3>{% trans "Confirm Deletion" %}</h3>

--- a/templates/delete_dip.html
+++ b/templates/delete_dip.html
@@ -7,9 +7,10 @@
 
 {% block content %}
   <ol class="breadcrumb">
+    {% trans "Untitled" as untitled %}
     <li class="breadcrumb-item"><a href="{% url 'collections' %}">{% trans "Collections" %}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'collection' dip.collection.pk %}">{{ dip.collection }}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'dip' dip.pk %}">{{ dip }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'collection' dip.collection.pk %}">{{ dip.collection.dc.title|default:untitled }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'dip' dip.pk %}">{{ dip.dc.title|default:untitled }}</a></li>
     <li class="breadcrumb-item active">{% trans "Delete" %}</li>
   </ol>
   <h3>{% trans "Confirm deletion" %}</h3>

--- a/templates/digitalfile.html
+++ b/templates/digitalfile.html
@@ -22,7 +22,7 @@
       <p><strong>{% trans "File format" %}:</strong> {{ digitalfile.fileformat }}</p>
       <p><strong>{% trans "File format version" %}:</strong> {{ digitalfile.formatversion }}</p>
       <p><strong>{% trans "Size (bytes)" %}:</strong> {{ digitalfile.size_bytes }}</p>
-      <p><strong>{% trans "Size (human readable)" %}:</strong> {{ digitalfile.size_human }}</p>
+      <p><strong>{% trans "Size (human readable)" %}:</strong> {{ digitalfile.size_bytes|filesizeformat }}</p>
       <p><strong>{% trans "Date modified" %}:</strong> {{ digitalfile.datemodified|default:"" }}</p>
       <p><strong>{% trans "PRONOM ID" %}:</strong> <a href="http://nationalarchives.gov.uk/PRONOM/{{digitalfile.puid}}">{{ digitalfile.puid }}</a></p>
       <p><strong>{% trans "METS amdSec" %}:</strong> {{ digitalfile.amdsec }}</p>

--- a/templates/digitalfile.html
+++ b/templates/digitalfile.html
@@ -16,7 +16,8 @@
   </ol>
   <div class="row">
     <div class="col-md-7">
-      <h2 class="mb-3">{% trans "Digital file description" %}</h2>
+      <h2 class="mb-4">{% trans "Digital file description" %}</h2>
+      <p class="mb-4"><strong>{{ digitalfile.filepath|basename }}</strong></p>
       <p><strong>{% trans "UUID" %}:</strong> {{ digitalfile.uuid }}</p>
       <p><strong>{% trans "Filepath" %}:</strong> {{ digitalfile.filepath }}</p>
       <p><strong>{% trans "File format" %}:</strong> {{ digitalfile.fileformat }}</p>

--- a/templates/digitalfile.html
+++ b/templates/digitalfile.html
@@ -18,16 +18,12 @@
     <div class="col-md-7">
       <h2 class="mb-4">{% trans "Digital file description" %}</h2>
       <p class="mb-4"><strong>{{ digitalfile.filepath|basename }}</strong></p>
-      <p><strong>{% trans "UUID" %}:</strong> {{ digitalfile.uuid }}</p>
       <p><strong>{% trans "Filepath" %}:</strong> {{ digitalfile.filepath }}</p>
       <p><strong>{% trans "File format" %}:</strong> {{ digitalfile.fileformat }}</p>
       <p><strong>{% trans "File format version" %}:</strong> {{ digitalfile.formatversion }}</p>
       <p><strong>{% trans "Size (bytes)" %}:</strong> {{ digitalfile.size_bytes }}</p>
       <p><strong>{% trans "Size (human readable)" %}:</strong> {{ digitalfile.size_bytes|filesizeformat }}</p>
       <p><strong>{% trans "Date modified" %}:</strong> {{ digitalfile.datemodified|default:"" }}</p>
-      <p><strong>{% trans "PRONOM ID" %}:</strong> <a href="http://nationalarchives.gov.uk/PRONOM/{{digitalfile.puid}}">{{ digitalfile.puid }}</a></p>
-      <p><strong>{% trans "METS amdSec" %}:</strong> {{ digitalfile.amdsec }}</p>
-      <p><strong>{% blocktrans %}Checksum ({{ digitalfile.hashtype }}){% endblocktrans %}:</strong> {{ digitalfile.hashvalue }}</p>
     </div>
     <div class="col-md-5 my-3 my-md-0">
       <h2 class="mb-3">{% trans "Attachments" %}</h2>

--- a/templates/digitalfile.html
+++ b/templates/digitalfile.html
@@ -9,10 +9,11 @@
 
 {% block content %}
   <ol class="breadcrumb">
+    {% trans "Untitled" as untitled %}
     <li class="breadcrumb-item"><a href="{% url 'collections' %}">{% trans "Collections" %}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'collection' digitalfile.dip.collection.pk %}">{{ digitalfile.dip.collection }}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'dip' digitalfile.dip.pk %}">{{ digitalfile.dip }}</a></li>
-    <li class="breadcrumb-item active">{{ digitalfile.uuid }}</li>
+    <li class="breadcrumb-item"><a href="{% url 'collection' digitalfile.dip.collection.pk %}">{{ digitalfile.dip.collection.dc.title|default:untitled }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'dip' digitalfile.dip.pk %}">{{ digitalfile.dip.dc.title|default:untitled }}</a></li>
+    <li class="breadcrumb-item active">{{ digitalfile.filepath|basename }}</li>
   </ol>
   <div class="row">
     <div class="col-md-7">

--- a/templates/dip.html
+++ b/templates/dip.html
@@ -56,7 +56,7 @@
         <tr>
           <td>{{ digital_file.filepath }}</td>
           <td>{{ digital_file.fileformat }}</td>
-          <td>{{ digital_file.size_bytes }}</td>
+          <td>{{ digital_file.size_bytes|filesizeformat }}</td>
           <td>{{ digital_file.datemodified|default:'' }}</td>
           <td>
             {% if 'import_status' not in digital_file.dip or digital_file.dip.import_status == statuses.SUCCESS %}

--- a/templates/dip.html
+++ b/templates/dip.html
@@ -9,9 +9,10 @@
 
 {% block content %}
   <ol class="breadcrumb">
+    {% trans "Untitled" as untitled %}
     <li class="breadcrumb-item"><a href="{% url 'collections' %}">{% trans "Collections" %}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'collection' dip.collection.pk %}">{{ dip.collection }}</a></li>
-    <li class="breadcrumb-item active">{{ dip }}</li>
+    <li class="breadcrumb-item"><a href="{% url 'collection' dip.collection.pk %}">{{ dip.collection.dc.title|default:untitled }}</a></li>
+    <li class="breadcrumb-item active">{{ dip.dc.title|default:untitled }}</li>
   </ol>
   <div class="row">
     <div class="col-md-7">

--- a/templates/edit_collection.html
+++ b/templates/edit_collection.html
@@ -7,8 +7,9 @@
 
 {% block content %}
   <ol class="breadcrumb">
+    {% trans "Untitled" as untitled %}
     <li class="breadcrumb-item"><a href="{% url 'collections' %}">{% trans "Collections" %}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'collection' collection.pk %}">{{ collection }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'collection' collection.pk %}">{{ collection.dc.title|default:untitled }}</a></li>
     <li class="breadcrumb-item active">{% trans "Edit" %}</li>
   </ol>
   <form method="post" novalidate>

--- a/templates/edit_dip.html
+++ b/templates/edit_dip.html
@@ -7,9 +7,10 @@
 
 {% block content %}
   <ol class="breadcrumb">
+    {% trans "Untitled" as untitled %}
     <li class="breadcrumb-item"><a href="{% url 'collections' %}">{% trans "Collections" %}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'collection' dip.collection.pk %}">{{ dip.collection }}</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'dip' dip.pk %}">{{ dip }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'collection' dip.collection.pk %}">{{ dip.collection.dc.title|default:untitled }}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'dip' dip.pk %}">{{ dip.dc.title|default:untitled }}</a></li>
     <li class="breadcrumb-item active">{% trans "Edit" %}</li>
   </ol>
   <form method="post" novalidate>

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -24,7 +24,7 @@
         <a class="nav-link{% if request.path == '/faq/' %} active{% endif %}" href="{% url 'faq' %}">{% trans "FAQ" %}</a>
       </li>
     </ul>
-    {% if user.is_authenticated %}
+    {% if user.is_authenticated and request.path != '/' and request.path != '/search/' %}
       <form method="get" action="{% url 'search' %}" class="form-inline mt-2 mt-md-0 mr-md-2 ml-md-4">
         <div class="input-group input-group-sm">
           <input type="text" name="query" class="form-control" placeholder="{% trans "Search all digital files" %}">

--- a/templates/search.html
+++ b/templates/search.html
@@ -31,7 +31,6 @@
           <td>{{ digital_file.datemodified|default:'' }}</td>
           {% trans "Untitled" as untitled %}
           <td><a href="{% url 'collection' digital_file.collection.id %}">{{ digital_file.collection.title|default:untitled }}</a></td>
-          <td><a href="{% url 'dip' digital_file.dip.id %}">{{ digital_file.dip.identifier }}</a></td>
           <td>
             {% if 'import_status' not in digital_file.dip or digital_file.dip.import_status == statuses.SUCCESS %}
               <a href="{% url 'digital_file' digital_file.meta.id %}" class="btn btn-sm btn-primary">{% trans "See more" %}</a>

--- a/templates/search.html
+++ b/templates/search.html
@@ -27,7 +27,7 @@
         <tr>
           <td>{{ digital_file.filepath }}</td>
           <td>{{ digital_file.fileformat }}</td>
-          <td>{{ digital_file.size_bytes }}</td>
+          <td>{{ digital_file.size_bytes|filesizeformat }}</td>
           <td>{{ digital_file.datemodified|default:'' }}</td>
           {% trans "Untitled" as untitled %}
           <td><a href="{% url 'collection' digital_file.collection.id %}">{{ digital_file.collection.title|default:untitled }}</a></td>


### PR DESCRIPTION
- Hide header search-box in home and search pages.
- Remove parent folder column in search page.
- Display human readable file size.
- Display filename in file page.
- Remove fields from file page.
- Display titles and filename in breadcrumbs.

Connects to #119.