### PR TITLE
Add digital filters tags

### DIFF
--- a/scope/static/js/custom.js
+++ b/scope/static/js/custom.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
     orientation: 'bottom auto',
     language: $('html')[0].lang,
   });
-  
+
   /*
   Language link click listener:
   Changes the language hidden input value on the sibling language
@@ -86,5 +86,36 @@ $(document).ready(function() {
     if (event.which == 13) {
       $(this).closest('form').submit();
     }
+  });
+
+  /* Remove digital file filter(s) on filter tag click. */
+  $('body').on('click', '.digital-file-filter-tag', function () {
+    var $this = $(this);
+    var url = new URL(document.location);
+    var param = $this.data('removeParam');
+    // Special case for dates
+    if (param === 'dates') {
+      // Remove both start_date and end_date params
+      url.searchParams.delete('start_date');
+      url.searchParams.delete('end_date');
+    } else {
+      // Remove only selected value on multiple selection params
+      var removeValue = $this.data('removeValue');
+      var values = url.searchParams.getAll(param);
+      var index = values.indexOf(removeValue);
+      if (index >= 0) {
+        values.splice(index, 1);
+        // Remove all values from URL
+        url.searchParams.delete(param);
+        // Add them one by one with append to use the same URL format
+        // as submitting the form, wich is `param=value1&param=value2`
+        // instead of `param=value1,value2` (used in set with array).
+        values.forEach(function(value) {
+          url.searchParams.append(param, value);
+        });
+      }
+    }
+    // Redirect with transformed URL
+    document.location.href = url.href;
   });
 });

--- a/scope/static/styles/main.scss
+++ b/scope/static/styles/main.scss
@@ -22,6 +22,7 @@
 @import "../vendor/bootstrap/scss/breadcrumb";
 @import "../vendor/bootstrap/scss/pagination";
 @import "../vendor/bootstrap/scss/alert";
+@import "../vendor/bootstrap/scss/badge";
 @import "../vendor/bootstrap/scss/close";
 @import "../vendor/bootstrap/scss/utilities";
 @import "../vendor/bootstrap/scss/print";

--- a/templates/dip.html
+++ b/templates/dip.html
@@ -38,14 +38,15 @@
   </div>
   <h2 class="mt-3">{% trans "Digital files in this folder" %}</h2>
   {% include 'includes/digital_file_filters.html' %}
-  <span class="d-inline-block mt-3 mb-2">
+  <span class="d-inline-block mt-3 mb-1 mr-1">
     {% blocktrans trimmed count counter=page.paginator.count %}
       <strong>{{ counter }}</strong> digital file
     {% plural %}
       <strong>{{ counter }}</strong> digital files
     {% endblocktrans %}
   </span>
-  <div class="table-responsive">
+  {% include 'includes/digital_file_filter_tags.html' %}
+  <div class="table-responsive pt-2">
     <table class="table table-striped table-condensed mb-0 border">
       {% include 'includes/table_header.html' with headers=table_headers %}
       {% if not digital_files %}

--- a/templates/includes/digital_file_filter_tags.html
+++ b/templates/includes/digital_file_filter_tags.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+
+{% for format in filters.formats %}
+  <a href="#" class="badge badge-primary mb-1 mr-1 digital-file-filter-tag" data-remove-param="for" data-remove-value="{{ format }}">
+    {{ format }}
+    <i class="fas fa-times ml-1"></i>
+  </a>
+{% endfor %}
+{% if filters.start_date or filters.end_date %}
+  {% trans "Undefined" as undefined %}
+  <a href="#" class="badge badge-primary mb-1 mr-1 digital-file-filter-tag" data-remove-param="dates">
+    {{ filters.start_date|default:undefined }} - {{ filters.end_date|default:undefined }}
+    <i class="fas fa-times ml-1"></i>
+  </a>
+{% endif %}
+{% for collection in filters.collections %}
+  <a href="#" class="badge badge-primary mb-1 mr-1 digital-file-filter-tag" data-remove-param="col" data-remove-value="{{ collection }}">
+    {{ collection }}
+    <i class="fas fa-times ml-1"></i>
+  </a>
+{% endfor %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -8,14 +8,15 @@
 {% block content %}
   <h2>{% trans "Search all digital files" %}</h2>
   {% include 'includes/digital_file_filters.html' %}
-  <span class="d-inline-block mt-3 mb-2">
+  <span class="d-inline-block mt-3 mb-1 mr-1">
     {% blocktrans trimmed count counter=page.paginator.count %}
       <strong>{{ counter }}</strong> digital file
     {% plural %}
       <strong>{{ counter }}</strong> digital files
     {% endblocktrans %}
   </span>
-  <div class="table-responsive">
+  {% include 'includes/digital_file_filter_tags.html' %}
+  <div class="table-responsive pt-2">
     <table class="table table-striped table-condensed mb-0 border">
       {% include 'includes/table_header.html' with headers=table_headers %}
       {% if not digital_files %}


### PR DESCRIPTION
Add link badges for selected filters over the results table in search
and DIPs pages. Add JS triggered by tag click to format the URL removing
the selected tag param(s) and redirect to the new URL.

Connects to #91.